### PR TITLE
Permitir la compilacion con compiladores y cmake mas nuevo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 # Add -Wall and -Wextra. Also,
 # treat C/C++ warnings as errors if -DADM_FATAL_WARNINGS=ON.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 # Add -Wall and -Wextra. Also,
 # treat C/C++ warnings as errors if -DADM_FATAL_WARNINGS=ON.

--- a/cpp/driver/CMakeLists.txt
+++ b/cpp/driver/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(matrix_creator_hal C CXX)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 set(CMAKE_BUILD_TYPE Release)
 

--- a/cpp/driver/creator_memory_map.h
+++ b/cpp/driver/creator_memory_map.h
@@ -19,6 +19,7 @@
 #define CPP_DRIVER_CREATOR_MEMORY_MAP_H_
 
 #include <string>
+#include <stdint.h>
 
 namespace matrix_hal {
 

--- a/cpp/driver/fw_data.h
+++ b/cpp/driver/fw_data.h
@@ -17,6 +17,7 @@
 
 #ifndef CPP_DRIVER_MCU_DATA_H_
 #define CPP_DRIVER_MCU_DATA_H_
+#include <stdint.h>
 
 namespace matrix_hal {
 

--- a/cpp/driver/uart_control.cpp
+++ b/cpp/driver/uart_control.cpp
@@ -59,7 +59,15 @@ UartControl::UartControl() : ucr_(0x0) {}
 void UartControl::Setup(MatrixIOBus *bus) {
   MatrixDriver::Setup(bus);
   // TODO(andres.calderon@admobilize.com): avoid systems calls
-  std::system("gpio edge 5 rising");
+  // FIXME: Remove the gpio command, it doesn't work on new kernels
+  // It can be modeled after the microphones code, by using a 
+  // condition variable and firing an interrupt.
+  // See microphone_array.cpp
+  int status = std::system("gpio edge 5 rising");
+  if (status != 0) {
+    std::cout << "Error executing gpio command" << std::endl;
+
+  }
 
   wiringPiSetupSys();
 

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(malos_service C CXX)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 add_definitions(-std=c++11)
 

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -16,7 +16,7 @@ FIND_LIBRARY(GFLAGS_LIB NAMES gflags)
 message(STATUS "gflags found =>" "${GFLAGS_LIB}") 
 
 add_subdirectory(../cpp/driver driver)
-add_subdirectory(../../paho.mqtt.c ${CMAKE_CURRENT_BINARY_DIR}/paho.mqtt_build)
+# add_subdirectory(../../paho.mqtt.c ${CMAKE_CURRENT_BINARY_DIR}/paho.mqtt_build)
 
 add_executable(compass_demo compass_demo.cpp)
   set_property(TARGET compass_demo PROPERTY CXX_STANDARD 11)

--- a/demos/mic_read_filter.cpp
+++ b/demos/mic_read_filter.cpp
@@ -15,9 +15,9 @@
 #include <fstream> // Input/output streams and functions
 #include <string> // Use strings
 
-#include "matrix_hal/matrixio_bus.h"     // Communicates with MATRIX device
-#include "matrix_hal/microphone_array.h" // Interfaces with microphone array
-#include "matrix_hal/microphone_core.h"  // Enables using FIR filter with microphone array
+#include "../cpp/driver/matrixio_bus.h"     // Communicates with MATRIX device
+#include "../cpp/driver/microphone_array.h" // Interfaces with microphone array
+#include "../cpp/driver/microphone_core.h"  // Enables using FIR filter with microphone array
 #include "mqtt/async_client.h" // MQTT C++ library
 
 //Constants for MQTT configuration

--- a/demos/simple_mic_read.cpp
+++ b/demos/simple_mic_read.cpp
@@ -14,11 +14,11 @@
 #include <chrono>
 
 // Communicates with MATRIX device
-#include "matrix_hal/matrixio_bus.h"
+#include "../cpp/driver/matrixio_bus.h"
 // Interfaces with microphone array
-#include "matrix_hal/microphone_array.h"
+#include "../cpp/driver/microphone_array.h"
 // Enables using FIR filter with microphone array
-#include "matrix_hal/microphone_core.h"
+#include "../cpp/driver/microphone_core.h"
 
 #include "mqtt/async_client.h"
 

--- a/demos/simple_mic_read.cpp
+++ b/demos/simple_mic_read.cpp
@@ -163,7 +163,7 @@ for (uint16_t c = 0; c < microphone_array.Channels(); c++) {
     // Convertir buffer[8][512] en un std::vector<std::vector<int16_t>>
     std::vector<std::vector<int16_t>> buffer_vec;
     buffer_vec.resize(rows);
-    for (int i = 0; i < rows; i++) {
+    for (size_t i = 0; i < rows; i++) {
         buffer_vec[i].assign(buffer[i], buffer[i] + cols);
     }
 

--- a/tfg/CMakeLists.txt
+++ b/tfg/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(matrix_read C CXX)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 add_definitions(-std=c++11)
 

--- a/tfg/audio_processor.cpp
+++ b/tfg/audio_processor.cpp
@@ -117,7 +117,7 @@ void process_beamforming(SafeQueue<AudioBlock>& queue, uint32_t frequency, int d
                 fftwf_execute_dft_c2r(plan_backward, cross_spectrum, gcc_phat);
 
                 // Buscar pico en GCC-PHAT para estimar TDOA
-                int max_idx = 0;
+                uint32_t max_idx = 0;
                 float max_val = -1e9;
                 for (uint32_t i = 0; i < block_size; ++i) {
                     if (gcc_phat[i] > max_val) {

--- a/tfg/audio_processor.hpp
+++ b/tfg/audio_processor.hpp
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <atomic>
-#include "matrix_hal/microphone_array.h"
+#include "../cpp/driver/microphone_array.h"
 #include "mqtt/async_client.h"
 #include "utils.hpp"
 

--- a/tfg/matrix_read.cpp
+++ b/tfg/matrix_read.cpp
@@ -9,9 +9,9 @@
 #include <vector>
 #include <gflags/gflags.h>
 #include <mqtt/async_client.h>
-#include "matrix_hal/matrixio_bus.h"
-#include "matrix_hal/microphone_array.h"
-#include "matrix_hal/microphone_core.h"
+#include "../cpp/driver/matrixio_bus.h"
+#include "../cpp/driver/microphone_array.h"
+#include "../cpp/driver/microphone_core.h"
 #include "audio_processor.hpp"
 #include "utils.hpp"
 


### PR DESCRIPTION

En esta pr permitimos la construccion con compiladores mas nuevos, al incluir
headers que faltan y subir la version minima de cmake a 3.5.

Tambien cambiamos los `#include` para que dependan de los header de la carpeta
local en demos/ y tfg/, de tal forma que los cambios en las librerias se vean
reflejados.

Por ultimo eliminamos warnings y pasamos a depender de la versiones instaladas
de paho en el sistema, de tal forma que generalizamos el proceso de compilacion
y eliminamos la necesidad de depender de una carpeta con la libreria de c de
paho en una ruta concreta
