### PR TITLE
Add a skeleton for python modules.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.5)
 include (cmake/FatalWarnings.cmake)
 ADM_EXTRA_WARNINGS()
 
-add_subdirectory(demos)
+
+# add_subdirectory(demos)
 add_subdirectory(tfg)
 

--- a/cpp/driver/CMakeLists.txt
+++ b/cpp/driver/CMakeLists.txt
@@ -48,6 +48,13 @@ add_library(matrix_creator_hal SHARED ${matrix_creator_hal_src})
   target_link_libraries(matrix_creator_hal ${FFTW_LIBRARIES})
   target_link_libraries(matrix_creator_hal ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} ${CRYPT_LIB})
 
+add_library(matrix_creator_hal_static STATIC ${matrix_creator_hal_src})
+  set_property(TARGET matrix_creator_hal_static PROPERTY CXX_STANDARD 11)
+  set_target_properties(matrix_creator_hal_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  target_link_libraries(matrix_creator_hal_static ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(matrix_creator_hal_static ${FFTW_LIBRARIES})
+  target_link_libraries(matrix_creator_hal_static ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} ${CRYPT_LIB})
+
 set (matrix_creator_hal_headers
   circular_queue.h
   creator_memory_map.h  
@@ -83,5 +90,6 @@ set (matrix_creator_hal_headers
 )
 
 install (TARGETS matrix_creator_hal DESTINATION lib)
+install (TARGETS matrix_creator_hal_static DESTINATION lib)
 
 install (FILES ${matrix_creator_hal_headers} DESTINATION include/matrix_hal)

--- a/tfg/CMakeLists.txt
+++ b/tfg/CMakeLists.txt
@@ -7,6 +7,8 @@ add_definitions(-std=c++11)
 include (../cmake/FatalWarnings.cmake)
 ADM_EXTRA_WARNINGS()
 
+add_subdirectory(../cpp/driver driver)
+
 find_package(Threads)
 #find_library (FFTW_LIBRARIES NAMES fftw3f )
 find_library (WIRINGPI_LIB NAMES wiringPi)
@@ -18,7 +20,7 @@ message(STATUS "gflags found =>" "${GFLAGS_LIB}")
 add_executable(matrix_read
   matrix_read.cpp
   audio_processor.cpp
-#  thread_manager.cpp
+# thread_manager.cpp
 )
 
 set_property(TARGET matrix_read PROPERTY CXX_STANDARD 11)

--- a/tfg/deps.md
+++ b/tfg/deps.md
@@ -1,0 +1,28 @@
+You need to install the neccesary packages to make this work
+
+```bash
+sudo apt install libpython3-dev pybind11-dev nanobind-dev python3
+```
+
+To test all this I use uv, which can be installed with
+```bash
+$ curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+and to test the pybind bindings go into the folder with the module the following command can be executed with bash
+```bash
+uv venv && uv pip install . && source .venv/bin/activate && python -c "import matrix_pybind; x = matrix_pybind.add(2,3); print(f'{x=}')" && deactivate && rm -rf .venv/
+```
+or this one one with fish
+```bash
+uv venv && uv pip install . && source .venv/bin/activate.fish && python -c "import matrix_pybind; x = matrix_pybind.add(2,3); print(f'{x=}')" && deactivate && rm -rf .venv/
+```
+
+To test the pybind bindings use 
+```bash
+uv venv && uv pip install . && source .venv/bin/activate && python -c "import matrix_nanobind; x = matrix_nanobind.add(2,3); print(f'{x=}')" && deactivate &&  rm -rf .venv/
+```
+or with fish
+```bash
+uv venv && uv pip install . && source .venv/bin/activate.fish && python -c "import matrix_nanobind; x = matrix_nanobind.add(2,3); print(f'{x=}')" && deactivate &&  rm -rf .venv/
+```

--- a/tfg/python/nanobind/CMakeLists.txt
+++ b/tfg/python/nanobind/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15...3.27)
-project(matrix_nanobind) 
+project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
 
 # Enable extra warnings. Not needed but keeps consistency
 include (../../../cmake/FatalWarnings.cmake)
@@ -34,12 +34,15 @@ find_library (WIRINGPI_DEV_LIB NAMES wiringPiDev)
 find_library (CRYPT_LIB NAMES crypt)
 find_library (GFLAGS_LIB NAMES gflags)
 
-nanobind_add_module(matrix_nanobind matrix_nanobind.cpp)
+# nanobind_add_module(matrix_nanobind matrix_nanobind.cpp)
+nanobind_add_module(matrix_nanobind NB_STATIC matrix_nanobind.cpp)
 set_property(TARGET matrix_nanobind PROPERTY CXX_STANDARD 17)
 
-target_link_libraries(matrix_nanobind PRIVATE matrix_creator_hal)
+target_link_libraries(matrix_nanobind PRIVATE matrix_creator_hal_static)
 target_link_libraries(matrix_nanobind PRIVATE ${CMAKE_THREAD_LIBS_INIT} )
 target_link_libraries(matrix_nanobind PRIVATE ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} ${CRYPT_LIB})
 target_link_libraries(matrix_nanobind PRIVATE ${GFLAGS_LIB})
 target_link_libraries(matrix_nanobind PRIVATE paho-mqttpp3 paho-mqtt3as)
+
+install(TARGETS matrix_nanobind LIBRARY DESTINATION .)
 

--- a/tfg/python/nanobind/CMakeLists.txt
+++ b/tfg/python/nanobind/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.15...3.27)
+project(matrix_nanobind) 
+
+# Enable extra warnings. Not needed but keeps consistency
+include (../../../cmake/FatalWarnings.cmake)
+ADM_EXTRA_WARNINGS()
+
+add_subdirectory(../../../cpp/driver driver)
+
+if (CMAKE_VERSION VERSION_LESS 3.18)
+  set(DEV_MODULE Development)
+else()
+  set(DEV_MODULE Development.Module)
+endif()
+
+find_package(Python 3.8 COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
+
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+
+# Detect the installed nanobind package and import it into CMake
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
+find_package(Threads)
+
+find_library (WIRINGPI_LIB NAMES wiringPi)
+find_library (WIRINGPI_DEV_LIB NAMES wiringPiDev)
+find_library (CRYPT_LIB NAMES crypt)
+find_library (GFLAGS_LIB NAMES gflags)
+
+nanobind_add_module(matrix_nanobind matrix_nanobind.cpp)
+set_property(TARGET matrix_nanobind PROPERTY CXX_STANDARD 17)
+
+target_link_libraries(matrix_nanobind PRIVATE matrix_creator_hal)
+target_link_libraries(matrix_nanobind PRIVATE ${CMAKE_THREAD_LIBS_INIT} )
+target_link_libraries(matrix_nanobind PRIVATE ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} ${CRYPT_LIB})
+target_link_libraries(matrix_nanobind PRIVATE ${GFLAGS_LIB})
+target_link_libraries(matrix_nanobind PRIVATE paho-mqttpp3 paho-mqtt3as)
+

--- a/tfg/python/nanobind/matrix_nanobind.cpp
+++ b/tfg/python/nanobind/matrix_nanobind.cpp
@@ -15,6 +15,7 @@ int add(int a, int b)
         std::cerr << "Couldn't find bus" << std::endl;
     }
 
+    std::cout << "Sum from nanobind" << std::endl;
     return a + b;
 }
 

--- a/tfg/python/nanobind/matrix_nanobind.cpp
+++ b/tfg/python/nanobind/matrix_nanobind.cpp
@@ -1,0 +1,24 @@
+#include "matrix_nanobind.hpp"
+
+#include "../../../cpp/driver/microphone_array.h"
+#include <ostream>
+#include <iostream>
+
+#include <nanobind/nanobind.h>
+
+int add(int a, int b)
+{
+    // Inicializar bus MATRIX
+    matrix_hal::MatrixIOBus bus;
+    if (!bus.Init())
+    {
+        std::cerr << "Couldn't find bus" << std::endl;
+    }
+
+    return a + b;
+}
+
+NB_MODULE(matrix_nanobind, m)
+{
+    m.def("add", &add);
+}

--- a/tfg/python/nanobind/matrix_nanobind.hpp
+++ b/tfg/python/nanobind/matrix_nanobind.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/tfg/python/nanobind/pyproject.toml
+++ b/tfg/python/nanobind/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["scikit-build-core", "nanobind"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "matrix_nanobind"
+version = "0.0.1"

--- a/tfg/python/pybind11/CMakeLists.txt
+++ b/tfg/python/pybind11/CMakeLists.txt
@@ -5,7 +5,7 @@
 # cmake -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") ..
 
 cmake_minimum_required(VERSION 3.15)
-project(matrix_read LANGUAGES CXX C)
+project(matrix_pybind LANGUAGES CXX C)
 
 # Enable extra warnings. Not needed but keeps consistency
 include (../../../cmake/FatalWarnings.cmake)
@@ -16,6 +16,7 @@ add_subdirectory(../../../cpp/driver driver)
 
 add_definitions(-std=c++11)
 find_package(Threads)
+
 set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
@@ -24,15 +25,15 @@ find_library (WIRINGPI_DEV_LIB NAMES wiringPiDev)
 find_library (CRYPT_LIB NAMES crypt)
 find_library (GFLAGS_LIB NAMES gflags)
 
-pybind11_add_module(matrix_python matrix_python.cpp)
-set_property(TARGET matrix_python PROPERTY CXX_STANDARD 11)
+pybind11_add_module(matrix_pybind matrix_python.cpp)
+set_property(TARGET matrix_pybind PROPERTY CXX_STANDARD 11)
 
-target_link_libraries(matrix_python PRIVATE matrix_creator_hal)
-target_link_libraries(matrix_python PRIVATE ${CMAKE_THREAD_LIBS_INIT} )
-target_link_libraries(matrix_python PRIVATE ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} ${CRYPT_LIB})
-target_link_libraries(matrix_python PRIVATE ${GFLAGS_LIB})
-target_link_libraries(matrix_python PRIVATE paho-mqttpp3 paho-mqtt3as)
+target_link_libraries(matrix_pybind PRIVATE matrix_creator_hal)
+target_link_libraries(matrix_pybind PRIVATE ${CMAKE_THREAD_LIBS_INIT} )
+target_link_libraries(matrix_pybind PRIVATE ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} ${CRYPT_LIB})
+target_link_libraries(matrix_pybind PRIVATE ${GFLAGS_LIB})
+target_link_libraries(matrix_pybind PRIVATE paho-mqttpp3 paho-mqtt3as)
 
 
-install(TARGETS matrix_python DESTINATION .)
+install(TARGETS matrix_pybind DESTINATION .)
 

--- a/tfg/python/pybind11/CMakeLists.txt
+++ b/tfg/python/pybind11/CMakeLists.txt
@@ -5,14 +5,14 @@
 # cmake -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") ..
 
 cmake_minimum_required(VERSION 3.15)
-project(matrix_pybind LANGUAGES CXX C)
+project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX C)
+
 
 # Enable extra warnings. Not needed but keeps consistency
 include (../../../cmake/FatalWarnings.cmake)
 ADM_EXTRA_WARNINGS()
 
 add_subdirectory(../../../cpp/driver driver)
-
 
 add_definitions(-std=c++11)
 find_package(Threads)
@@ -28,12 +28,15 @@ find_library (GFLAGS_LIB NAMES gflags)
 pybind11_add_module(matrix_pybind matrix_python.cpp)
 set_property(TARGET matrix_pybind PROPERTY CXX_STANDARD 11)
 
-target_link_libraries(matrix_pybind PRIVATE matrix_creator_hal)
+target_link_libraries(matrix_pybind PRIVATE matrix_creator_hal_static)
 target_link_libraries(matrix_pybind PRIVATE ${CMAKE_THREAD_LIBS_INIT} )
 target_link_libraries(matrix_pybind PRIVATE ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} ${CRYPT_LIB})
 target_link_libraries(matrix_pybind PRIVATE ${GFLAGS_LIB})
 target_link_libraries(matrix_pybind PRIVATE paho-mqttpp3 paho-mqtt3as)
 
+# install(TARGETS matrix_pybind DESTINATION .)
+install(TARGETS matrix_pybind LIBRARY DESTINATION .)
 
-install(TARGETS matrix_pybind DESTINATION .)
+
+
 

--- a/tfg/python/pybind11/CMakeLists.txt
+++ b/tfg/python/pybind11/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Need pybind11 installed 
+
+# To use this is recommended 
+# This often is a good way to get the current Python, works in environments:
+# cmake -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") ..
+
+cmake_minimum_required(VERSION 3.15)
+project(matrix_read LANGUAGES CXX C)
+
+# Enable extra warnings. Not needed but keeps consistency
+include (../../../cmake/FatalWarnings.cmake)
+ADM_EXTRA_WARNINGS()
+
+add_subdirectory(../../../cpp/driver driver)
+
+
+add_definitions(-std=c++11)
+find_package(Threads)
+set(PYBIND11_FINDPYTHON ON)
+find_package(pybind11 CONFIG REQUIRED)
+
+find_library (WIRINGPI_LIB NAMES wiringPi)
+find_library (WIRINGPI_DEV_LIB NAMES wiringPiDev)
+find_library (CRYPT_LIB NAMES crypt)
+find_library (GFLAGS_LIB NAMES gflags)
+
+pybind11_add_module(matrix_python matrix_python.cpp)
+set_property(TARGET matrix_python PROPERTY CXX_STANDARD 11)
+
+target_link_libraries(matrix_python PRIVATE matrix_creator_hal)
+target_link_libraries(matrix_python PRIVATE ${CMAKE_THREAD_LIBS_INIT} )
+target_link_libraries(matrix_python PRIVATE ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} ${CRYPT_LIB})
+target_link_libraries(matrix_python PRIVATE ${GFLAGS_LIB})
+target_link_libraries(matrix_python PRIVATE paho-mqttpp3 paho-mqtt3as)
+
+
+install(TARGETS matrix_python DESTINATION .)
+

--- a/tfg/python/pybind11/matrix_python.cpp
+++ b/tfg/python/pybind11/matrix_python.cpp
@@ -15,6 +15,8 @@ int add(int i, int j)
         std::cerr << "Couldn't find bus" << std::endl;
     }
 
+
+    std::cout << "Sum from pybind" << std::endl;
     return i + j;
 }
 

--- a/tfg/python/pybind11/matrix_python.cpp
+++ b/tfg/python/pybind11/matrix_python.cpp
@@ -1,13 +1,25 @@
 #include "matrix_python.hpp"
 
+#include "../../../cpp/driver/microphone_array.h"
+#include <ostream>
+#include <iostream>
 
 #include <pybind11/pybind11.h>
 
-int add(int i, int j) {
+int add(int i, int j)
+{
+    // Inicializar bus MATRIX
+    matrix_hal::MatrixIOBus bus;
+    if (!bus.Init())
+    {
+        std::cerr << "Couldn't find bus" << std::endl;
+    }
+
     return i + j;
 }
 
-PYBIND11_MODULE(matrix_python, m) {
+PYBIND11_MODULE(matrix_pybind, m)
+{
     m.doc() = "pybind11 example plugin"; // optional module docstring
 
     m.def("add", &add, "A function that adds two numbers");

--- a/tfg/python/pybind11/matrix_python.cpp
+++ b/tfg/python/pybind11/matrix_python.cpp
@@ -1,0 +1,14 @@
+#include "matrix_python.hpp"
+
+
+#include <pybind11/pybind11.h>
+
+int add(int i, int j) {
+    return i + j;
+}
+
+PYBIND11_MODULE(matrix_python, m) {
+    m.doc() = "pybind11 example plugin"; // optional module docstring
+
+    m.def("add", &add, "A function that adds two numbers");
+}

--- a/tfg/python/pybind11/matrix_python.hpp
+++ b/tfg/python/pybind11/matrix_python.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/tfg/python/pybind11/pyproject.toml
+++ b/tfg/python/pybind11/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["scikit-build-core", "pybind11"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "matrix_pybind"
+version = "0.1.0"


### PR DESCRIPTION

This PR include an skeleton for binding to python the c++ library by using two
libraries: pybind11 and nanobind.

- The pybind11 library is older and only needs c++-11, and probably has more
  documentation and examples around the internet.

- The nanobind library is newer, needs c++-17, and probably has less
  documentation, but it's nicer to use.

In both cases there is a very simple module that tries to access the bus of the
matrix-io (to check it's working correctly and that we are able to link the
libraries) and perform a sum of two arguments.

Note that in both cases the -lmatrix-hal library is linked statically, because
otherwise it couldn't fine the .so when importing the module.  

There is a document detailing how to test the artifacts, but basically a
virtualenv is created and the libraries are installed in editable mode with 
`pip install -e . `

The PR also includes a couple of build fixes, when building tfg/ and when
building from the root.