### PR TITLE
Python stub of the audio interface.

### DIFF
--- a/tfg/python/pybind11-test/CMakeLists.txt
+++ b/tfg/python/pybind11-test/CMakeLists.txt
@@ -14,7 +14,7 @@ ADM_EXTRA_WARNINGS()
 
 add_subdirectory(../../../cpp/driver driver)
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++17)
 find_package(Threads)
 
 set(PYBIND11_FINDPYTHON ON)

--- a/tfg/python/pybind11-test/CMakeLists.txt
+++ b/tfg/python/pybind11-test/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Need pybind11 installed 
+
+# To use this is recommended 
+# This often is a good way to get the current Python, works in environments:
+# cmake -DPYTHON_EXECUTABLE=$(python3 -c "import sys; print(sys.executable)") ..
+
+cmake_minimum_required(VERSION 3.15)
+project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX C)
+
+
+# Enable extra warnings. Not needed but keeps consistency
+include (../../../cmake/FatalWarnings.cmake)
+ADM_EXTRA_WARNINGS()
+
+add_subdirectory(../../../cpp/driver driver)
+
+add_definitions(-std=c++11)
+find_package(Threads)
+
+set(PYBIND11_FINDPYTHON ON)
+find_package(pybind11 CONFIG REQUIRED)
+
+find_library (WIRINGPI_LIB NAMES wiringPi)
+find_library (WIRINGPI_DEV_LIB NAMES wiringPiDev)
+find_library (CRYPT_LIB NAMES crypt)
+find_library (GFLAGS_LIB NAMES gflags)
+
+pybind11_add_module(matrix_pybind matrix_python.cpp)
+set_property(TARGET matrix_pybind PROPERTY CXX_STANDARD 11)
+
+target_link_libraries(matrix_pybind PRIVATE matrix_creator_hal_static)
+target_link_libraries(matrix_pybind PRIVATE ${CMAKE_THREAD_LIBS_INIT} )
+target_link_libraries(matrix_pybind PRIVATE ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} ${CRYPT_LIB})
+target_link_libraries(matrix_pybind PRIVATE ${GFLAGS_LIB})
+target_link_libraries(matrix_pybind PRIVATE paho-mqttpp3 paho-mqtt3as)
+
+# install(TARGETS matrix_pybind DESTINATION .)
+install(TARGETS matrix_pybind LIBRARY DESTINATION .)
+
+
+
+

--- a/tfg/python/pybind11-test/example.cpp
+++ b/tfg/python/pybind11-test/example.cpp
@@ -1,3 +1,239 @@
+// This is a test resembiling the desired audio interface to implement in c++
+//
+// Run this with the command: `g++  -lpthread -lfmt example.cpp -o example && ./example`
+// Known to run under g++ 14.2.0 in ubuntu 25.04 plucky
 #include "example.hpp"
+#include <iostream>
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 
-int main() {}
+class AudioConsumer
+{
+private:
+    std::thread bck_thread;
+    std::atomic<bool> async_running;
+    SafeQueue<Block> queue;
+    int async_sleep_time_ms{512};
+    int start_async_sleep_ms{10};
+
+private:
+    Block producer_sync();
+    void producer_async();
+    void setup_resources(int freq, int gain);
+
+public:
+    AudioConsumer(int freq, int gain);
+    ~AudioConsumer();
+    void start_async();
+    void stop_async();
+    Block read_sync();
+    Block read_async();
+};
+
+AudioConsumer::AudioConsumer(int freq, int gain) : bck_thread{}, async_running{false}, queue{}
+{
+    // Initialize all the important member variables in the constructor.
+    // Note that the thread must be initialized with the default constructor,
+    // and later started in start_async, to be able to work correctly.
+    // See the link in start_async.
+    setup_resources(freq, gain);
+}
+
+void AudioConsumer::setup_resources(int freq, int gain)
+{
+    // Empty function in this case, relevant in the case of the matrix.
+    // Important question how to propagate errors in initialization?
+    // Normally in c++ you use an exception, but I don't know how well they translate with pybind.
+    // An option is to use an error status/error code pair in the class, and set them on error.
+    auto f = freq;
+    auto g = gain;
+    g = f;
+    f = g;
+}
+
+AudioConsumer::~AudioConsumer()
+{
+    async_running = false;
+    if (bck_thread.joinable())
+    {
+        bck_thread.join();
+    }
+}
+
+void AudioConsumer::start_async()
+{
+    using namespace std::literals::chrono_literals;
+    if (async_running)
+    {
+        return;
+    }
+    async_running = true;
+    // As we are in a class all methods have an implicit pointer to the current instance as a first parameter.
+    // See https://rafalcieslak.wordpress.com/2014/05/16/c11-stdthreads-managed-by-a-designated-class/ for an example
+    this->bck_thread = std::move(std::thread(&AudioConsumer::producer_async, this));
+
+    // Sleep the current thread to give time for the producer to start.
+    std::this_thread::sleep_for(start_async_sleep_ms * 1ms);
+}
+
+void AudioConsumer::stop_async()
+{
+    if (!async_running)
+    {
+        return;
+    }
+
+    async_running = false;
+    Block b{};
+    while (this->queue.pop(b))
+    {
+        b = Block{};
+    }
+
+    if (bck_thread.joinable())
+    {
+        bck_thread.join();
+    }
+    bck_thread = std::thread{};
+}
+
+Block AudioConsumer::producer_sync()
+{
+    Block x{};
+    x.samples = std::move(std::vector<int>{});
+    x.samples.reserve(BLOCK_SIZE);
+    for (size_t i = 0; i < BLOCK_SIZE; i++)
+    {
+        auto num = std::rand();
+        x.samples.emplace_back(num);
+    }
+    return x;
+}
+
+Block AudioConsumer::read_sync()
+{
+    if (async_running)
+    {
+        return Block{};
+    }
+    return producer_sync();
+}
+
+void AudioConsumer::producer_async()
+{
+    using namespace std::literals::chrono_literals;
+    while (async_running)
+    {
+        Block x{};
+        x.samples = std::move(std::vector<int>{});
+        x.samples.reserve(BLOCK_SIZE);
+        for (size_t i = 0; i < BLOCK_SIZE; i++)
+        {
+            auto num = std::rand();
+            x.samples.emplace_back(num);
+        }
+        queue.push(x);
+        std::cout << "Producing" << std::endl;
+        std::this_thread::sleep_for(async_sleep_time_ms * 1ms);
+    }
+}
+
+Block AudioConsumer::read_async()
+{
+    if (!async_running)
+    {
+        return Block{};
+    }
+
+    Block b{};
+    bool have_data = queue.pop(b);
+    if (have_data)
+    {
+        return b;
+    }
+    else
+    {
+        return Block{};
+    }
+}
+
+int main()
+{
+    // NOTE: We use scopes to run destructors and allow copy paste with the same code in diferent cases.
+    using namespace std::literals::chrono_literals;
+
+    auto aud = AudioConsumer{16000, 3};
+    aud.start_async();
+    {
+        auto v_ex = aud.read_async();
+        auto sples = v_ex.samples;
+        if (sples.empty()) {std::cerr << "[]" << std::endl;}
+        for (auto s : sples)
+        {
+            std::cerr << s << std::endl;
+        }
+    }
+
+    std::cerr << "Read async again, expect empty vector" << std::endl;
+    {
+        auto v_ex = aud.read_async();
+        auto sples = v_ex.samples;
+        if (sples.empty()) {std::cerr << "[]" << std::endl;}
+        for (auto s : sples)
+        {
+            std::cerr << s << std::endl;
+        }
+    }
+
+    std::cerr << "Read sync, when async is active expect empty vector" << std::endl;
+    {
+        auto v_ex = aud.read_sync();
+        auto sples = v_ex.samples;
+        if (sples.empty()) {std::cerr << "[]" << std::endl;}
+        for (auto s : sples)
+        {
+            std::cerr << s << std::endl;
+        }
+    }
+
+    std::this_thread::sleep_for(512*1ms);
+
+    std::cerr << "Read async again, after sleep" << std::endl;
+    {
+        auto v_ex = aud.read_async();
+        auto sples = v_ex.samples;
+        if (sples.empty()) {std::cerr << "[]" << std::endl;}
+        for (auto s : sples)
+        {
+            std::cerr << s << std::endl;
+        }
+    }
+
+
+    std::cerr << "Stop async, begin read sync" << std::endl;
+    aud.stop_async();
+    {
+        auto v_ex = aud.read_sync();
+        auto sples = v_ex.samples;
+        if (sples.empty()) {std::cerr << "[]" << std::endl;}
+        for (auto s : sples)
+        {
+            std::cerr << s << std::endl;
+        }
+    }
+
+    std::cerr << "Start async again and read" << std::endl;
+    aud.start_async();
+    {
+        auto v_ex = aud.read_async();
+        auto sples = v_ex.samples;
+        if (sples.empty()) {std::cerr << "[]" << std::endl;}
+        for (auto s : sples)
+        {
+            std::cerr << s << std::endl;
+        }
+    }
+
+    std::cerr << "Last don't stop async and expect no crash, as the the thread joins in the destructor" << std::endl;
+}

--- a/tfg/python/pybind11-test/example.cpp
+++ b/tfg/python/pybind11-test/example.cpp
@@ -1,0 +1,3 @@
+#include "example.hpp"
+
+int main() {}

--- a/tfg/python/pybind11-test/example.hpp
+++ b/tfg/python/pybind11-test/example.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/tfg/python/pybind11-test/example.hpp
+++ b/tfg/python/pybind11-test/example.hpp
@@ -1,1 +1,46 @@
 #pragma once
+
+#include <vector>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+#include <random>
+#include <atomic>
+
+#define BLOCK_SIZE 512
+
+template<typename T>
+class SafeQueue {
+private:
+    std::queue<T> queue_;
+    std::mutex mutex_;
+    std::condition_variable cond_;
+public:
+    void push(const T& item) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            queue_.push(item);
+        }
+        cond_.notify_one();
+    }
+
+    bool pop(T& item) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (queue_.empty()) return false;
+        item = queue_.front();
+        queue_.pop();
+        return true;
+    }
+
+    void wait_pop(T& item) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cond_.wait(lock, [&] { return !queue_.empty(); });
+        item = queue_.front();
+        queue_.pop();
+    }
+};
+
+struct Block {
+    std::vector<int> samples;
+};

--- a/tfg/python/pybind11-test/matrix_python.cpp
+++ b/tfg/python/pybind11-test/matrix_python.cpp
@@ -1,0 +1,28 @@
+#include "matrix_python.hpp"
+
+#include "../../../cpp/driver/microphone_array.h"
+#include <ostream>
+#include <iostream>
+
+#include <pybind11/pybind11.h>
+
+int add(int i, int j)
+{
+    // Inicializar bus MATRIX
+    matrix_hal::MatrixIOBus bus;
+    if (!bus.Init())
+    {
+        std::cerr << "Couldn't find bus" << std::endl;
+    }
+
+
+    std::cout << "Sum from pybind" << std::endl;
+    return i + j;
+}
+
+PYBIND11_MODULE(matrix_pybind, m)
+{
+    m.doc() = "pybind11 example plugin"; // optional module docstring
+
+    m.def("add", &add, "A function that adds two numbers");
+}

--- a/tfg/python/pybind11-test/matrix_python.cpp
+++ b/tfg/python/pybind11-test/matrix_python.cpp
@@ -208,11 +208,29 @@ int AudioConsumer::len_async_queue()
 
 int add(int i, int j) { return i + j; }
 
+std::vector<std::vector<int16_t>> test_vec()
+{
+    std::vector<std::vector<int16_t>> ret{};
+    for (size_t i = 0; i < 8; i++)
+    {
+        std::vector<int16_t> v{};
+        for (size_t j = 0; j < 512; j++)
+        {
+            v.push_back(i * 512 + j);
+        }
+        ret.push_back(v);
+    }
+
+    return ret;
+}
+
 PYBIND11_MODULE(matrix_pybind, m)
 {
     m.doc() = "pybind11 example plugin"; // optional module docstring
 
     m.def("add", &add, "A function that adds two numbers");
+
+    m.def("v", &test_vec, "A function that return a multidimensional vector of int16_t");
 
     py::classh<AudioConsumer>(m, "AudioConsumer")
         .def(py::init<const int, const int>())

--- a/tfg/python/pybind11-test/matrix_python.cpp
+++ b/tfg/python/pybind11-test/matrix_python.cpp
@@ -1,28 +1,224 @@
 #include "matrix_python.hpp"
-
-#include "../../../cpp/driver/microphone_array.h"
-#include <ostream>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/chrono.h>
+#include <pybind11/functional.h>
 #include <iostream>
 
-#include <pybind11/pybind11.h>
+namespace py = pybind11;
 
-int add(int i, int j)
+// Important question how to propagate errors in initialization?  Or during a
+// read (we use return emtpy vectors, on error, but there are several causes)?
+// Normally in c++ you use an exception, but I don't know how well they
+// translate with pybind.  An option is to use an error status/error code pair
+// in the class, and set them on error, but we have to perform cleaup and this
+// may be messy and error-prone.
+
+void producer_async_fun(SafeQueue<Block> &queue,
+                        std::atomic<bool> &running,
+                        std::atomic<int> &len_queue,
+                        int async_sleep_time_ms)
 {
-    // Inicializar bus MATRIX
-    matrix_hal::MatrixIOBus bus;
-    if (!bus.Init())
+    using namespace std::literals::chrono_literals;
+    while (running)
     {
-        std::cerr << "Couldn't find bus" << std::endl;
+        Block x{};
+        x.samples = std::vector<int>{};
+        x.samples.reserve(BLOCK_SIZE);
+
+        for (size_t i = 0; i < BLOCK_SIZE; i++)
+        {
+            auto num = std::rand();
+            x.samples.emplace_back(num);
+        }
+
+        queue.push(x);
+        len_queue++;
+
+        std::this_thread::sleep_for(async_sleep_time_ms * 1ms);
+    }
+}
+
+class AudioConsumer
+{
+private:
+    std::thread bck_thread;
+    std::atomic<bool> async_running;
+    SafeQueue<Block> queue;
+    std::atomic<int> len_queue{0};
+    int async_sleep_time_ms{512};
+
+private:
+    Block producer_sync();
+    void producer_async();
+    void setup_resources(int freq, int gain);
+
+public:
+    AudioConsumer(int freq, int gain);
+    ~AudioConsumer();
+    void start_async();
+    void stop_async(bool drain_queue = false);
+    std::vector<int> read_sync();
+    std::vector<int> read_async();
+    int len_async_queue();
+};
+
+AudioConsumer::AudioConsumer(const int freq, const int gain) : bck_thread{}, async_running{false}, queue{}
+{
+    // Initialize all the important member variables in the constructor.
+    // Note that the thread must be initialized with the default constructor,
+    // and later started in start_async, to be able to work correctly.
+    // See the link in start_async.
+    setup_resources(freq, gain);
+}
+
+void AudioConsumer::setup_resources(int freq, int gain)
+{
+    // Nonsensical function in this case, but, relevant in the case of the matrix.
+    auto f = freq;
+    auto g = gain;
+    g = f;
+    f = g;
+}
+
+AudioConsumer::~AudioConsumer()
+{
+    py::gil_scoped_release release; // Release the GIL in this function
+
+    async_running = false;
+
+    if (bck_thread.joinable())
+    {
+        bck_thread.join();
+    }
+}
+
+void AudioConsumer::start_async()
+{
+    using namespace std::literals::chrono_literals;
+
+    py::gil_scoped_release release; // Release the GIL in this function
+
+    if (async_running)
+    {
+        return;
     }
 
+    async_running = true;
 
-    std::cout << "Sum from pybind" << std::endl;
-    return i + j;
+    // As we are in a class all methods have an implicit pointer to the current instance as a first parameter.
+    // See https://rafalcieslak.wordpress.com/2014/05/16/c11-stdthreads-managed-by-a-designated-class/ for an example
+    // this->bck_thread = std::move(std::thread(&AudioConsumer::producer_async, this)); // With pybind11, spawning a thread doesn't work with a class method.
+
+    this->bck_thread = std::move(std::thread(
+        &producer_async_fun,
+        std::ref(queue),
+        std::ref(async_running),
+        std::ref(len_queue),
+        async_sleep_time_ms)); // But, it works with a free function
 }
+
+void AudioConsumer::stop_async(bool drain_queue /* = false */)
+{
+    py::gil_scoped_release release; // Release the GIL in this function
+
+    if (!async_running)
+    {
+        return;
+    }
+
+    async_running = false;
+
+    if (drain_queue)
+    {
+        Block b{};
+        while (this->queue.pop(b))
+        {
+            len_queue--;
+        }
+    }
+
+    if (bck_thread.joinable())
+    {
+        bck_thread.join();
+    }
+}
+
+Block AudioConsumer::producer_sync()
+{
+    Block x{};
+    x.samples.reserve(BLOCK_SIZE);
+    for (size_t i = 0; i < BLOCK_SIZE; i++)
+    {
+        auto num = std::rand();
+        x.samples.emplace_back(num);
+    }
+    return x;
+}
+
+std::vector<int> AudioConsumer::read_sync()
+{
+    Block ret;
+    if (async_running)
+    {
+        return ret.samples; // Return empty vector if we are in async reading mode.
+    }
+
+    ret = producer_sync();
+    return ret.samples;
+}
+
+void AudioConsumer::producer_async()
+{
+    using namespace std::literals::chrono_literals;
+
+    while (async_running)
+    {
+        Block x{};
+        x.samples = std::move(std::vector<int>{});
+        x.samples.reserve(BLOCK_SIZE);
+        for (size_t i = 0; i < BLOCK_SIZE; i++)
+        {
+            auto num = std::rand();
+            x.samples.emplace_back(num);
+        }
+        queue.push(x);
+        std::this_thread::sleep_for(async_sleep_time_ms * 1ms);
+    }
+}
+
+std::vector<int> AudioConsumer::read_async()
+{
+
+    Block b{};
+    bool have_data = queue.pop(b);
+    if (!async_running && !have_data)
+    {
+        return b.samples; // Empty vector if we are not in async mode or we have no more data to return.
+    }
+
+    len_queue--;
+    return b.samples;
+}
+
+int AudioConsumer::len_async_queue()
+{
+    return len_queue.load();
+}
+
+int add(int i, int j) { return i + j; }
 
 PYBIND11_MODULE(matrix_pybind, m)
 {
     m.doc() = "pybind11 example plugin"; // optional module docstring
 
     m.def("add", &add, "A function that adds two numbers");
+
+    py::classh<AudioConsumer>(m, "AudioConsumer")
+        .def(py::init<const int, const int>())
+        .def("start_async", &AudioConsumer::start_async)
+        .def("stop_async", &AudioConsumer::stop_async, py::arg("drain") = false)
+        .def("len_async_queue", &AudioConsumer::len_async_queue)
+        .def("read_async", &AudioConsumer::read_async)
+        .def("read_sync", &AudioConsumer::read_sync);
 }

--- a/tfg/python/pybind11-test/matrix_python.hpp
+++ b/tfg/python/pybind11-test/matrix_python.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/tfg/python/pybind11-test/matrix_python.hpp
+++ b/tfg/python/pybind11-test/matrix_python.hpp
@@ -7,6 +7,7 @@
 #include <thread>
 #include <random>
 #include <atomic>
+#include <cstdint>
 
 #define BLOCK_SIZE 512
 

--- a/tfg/python/pybind11-test/matrix_python.hpp
+++ b/tfg/python/pybind11-test/matrix_python.hpp
@@ -1,1 +1,46 @@
 #pragma once
+
+#include <vector>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+#include <random>
+#include <atomic>
+
+#define BLOCK_SIZE 512
+
+template<typename T>
+class SafeQueue {
+private:
+    std::queue<T> queue_;
+    std::mutex mutex_;
+    std::condition_variable cond_;
+public:
+    void push(const T& item) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            queue_.push(item);
+        }
+        cond_.notify_one();
+    }
+
+    bool pop(T& item) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (queue_.empty()) return false;
+        item = queue_.front();
+        queue_.pop();
+        return true;
+    }
+
+    void wait_pop(T& item) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cond_.wait(lock, [&] { return !queue_.empty(); });
+        item = queue_.front();
+        queue_.pop();
+    }
+};
+
+struct Block {
+    std::vector<int> samples;
+};

--- a/tfg/python/pybind11-test/pyproject.toml
+++ b/tfg/python/pybind11-test/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["scikit-build-core", "pybind11"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "matrix_pybind"
+version = "0.1.0"

--- a/tfg/python/pybind11-test/pyproject.toml
+++ b/tfg/python/pybind11-test/pyproject.toml
@@ -5,3 +5,6 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "matrix_pybind"
 version = "0.1.0"
+dependencies = [
+    "ipython>=9.4.0",
+]


### PR DESCRIPTION
This PR show an example of which I think should be the python interface to read
audio.

The main highlights are the following:

- It's a class based design, so the threads are not global, and it's possible to
avoid resource leakage in long-running programs, as we can join all threads (in
the destructor if not done manually) and don't need to detach threads.

- We avoid global variables, so in *theory* it should be possible to have more
than one instance of the class, in the same program. We have to experiment if
we have resource contention with the access to the microphones.

- We expose five functions in the class:

1. `read_sync`: Read directly from the source and returns a list with the data
   (here a number-generating function, in the matrix the Read() function of the
   Microphones).
   If we are reading in async mode return an empty list to signal an error, as
   we don't want to have a race condition between the main thread and the
   background one causing a block the async read,

1. `start_async`: Start a background thread, which periodically reads from the
   source and puts the result in a thread-safe queue (here we sleep to simulate
   the blocking with a condition variable of the matrix until more data is
   available).

1. `read_async`: Reads from the thread-safe queue, and returns a list with the
   data of the first block. If there are no more blocks or we are not in
   async_mode return an empty list.

1. `stop_async`: Stops (joins) the async reads. This function has a parameter
   to clean up the async queue, which is false to default, to allow stopping
   the thread and continue reading the samples already recorded. The queue cleanup
   may be useful when performing multiple async_{start/stop} cycles, to read at
   different times.

1. `len_async_queue`: Returns the number of elements on the queue by
   incrementing an integer in the producer and decreasing in the consumers.
   This is useful to know how many seconds of recording we have in the queue,
   as we know the sampling frequency and the number of samples per block.
   (We should probably integrate this functionality directly in the thread-safe
   queue, instead of doing it like this).

- This PR also includes a function to demonstrate the return of
`std::vector<std::vector<int16_t>>` from c++ to python, as for further
implementation simplicity we have decided to use `std::vector<int>` in all
relevant functions.

In the first commits we did a pure c++ implementation for testing, but the
python bindings have a significant difference: **The thread launches a free
function and not a class method**, as with pybind trying to launch a class
function in a thread crashes the program.

It's also very important to be careful when realising the GIL. Now we only
release it in function that spawn or join a thread. Trying to release the GIL
in the async producer or consumer functions *crashes* the program.

Also we should return `std::vector<...>` instead of a Block to simplify the code and 
back-and-forth conversion, as a vector is converted to a python `list`
